### PR TITLE
Fix retry template backoff property

### DIFF
--- a/src/main/java/com/example/aqa/configuration/common/CommonConfiguration.java
+++ b/src/main/java/com/example/aqa/configuration/common/CommonConfiguration.java
@@ -13,7 +13,7 @@ public class CommonConfiguration {
     public RetryTemplate assertionRetry(RetryProperties properties) {
         return RetryTemplate.builder().retryOn(AssertionError.class)
                 .maxAttempts(properties.getAttempts())
-                .fixedBackoff(properties.getAttempts())
+                .fixedBackoff(properties.getBackoff())
                 .build();
     }
 }


### PR DESCRIPTION
## Summary
- ensure retry template uses dedicated backoff value instead of attempts

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6899f8eecc388326a186dc4b3391842b