### PR TITLE
Fix extension package naming

### DIFF
--- a/src/main/java/com/example/aqa/configuration/MainConfiguration.java
+++ b/src/main/java/com/example/aqa/configuration/MainConfiguration.java
@@ -1,6 +1,6 @@
 package com.example.aqa.configuration;
 
-import com.example.aqa.configuration.extesion.ExtensionConfiguration;
+import com.example.aqa.configuration.extension.ExtensionConfiguration;
 import com.example.aqa.configuration.rest.RestApiClientConfiguration;
 import com.example.aqa.configuration.driver.appium.AppiumConfiguration;
 import com.example.aqa.driver.AppDriver;

--- a/src/main/java/com/example/aqa/configuration/extension/ExtensionConfiguration.java
+++ b/src/main/java/com/example/aqa/configuration/extension/ExtensionConfiguration.java
@@ -1,6 +1,6 @@
-package com.example.aqa.configuration.extesion;
+package com.example.aqa.configuration.extension;
 
-import com.example.aqa.junit.extesion.ScreenshotOnFailureExtension;
+import com.example.aqa.junit.extension.ScreenshotOnFailureExtension;
 import io.appium.java_client.AppiumDriver;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/example/aqa/junit/extension/ScreenshotOnFailureExtension.java
+++ b/src/main/java/com/example/aqa/junit/extension/ScreenshotOnFailureExtension.java
@@ -1,4 +1,4 @@
-package com.example.aqa.junit.extesion;
+package com.example.aqa.junit.extension;
 
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;

--- a/src/test/java/com/example/aqa/BaseTest.java
+++ b/src/test/java/com/example/aqa/BaseTest.java
@@ -3,7 +3,7 @@ package com.example.aqa;
 import com.example.aqa.app.client.PageExample;
 import com.example.aqa.app.server.RestApiClient;
 import com.example.aqa.configuration.MainConfiguration;
-import com.example.aqa.junit.extesion.ScreenshotOnFailureExtension;
+import com.example.aqa.junit.extension.ScreenshotOnFailureExtension;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
## Summary
- rename `extesion` packages to `extension`
- update package declarations and imports

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.example:template:0.0.1-SNAPSHOT: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6899fcfc3954832689c626cb17fc99a4