### PR TITLE
feat: add selenium profile configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This project demonstrates a minimal yet extensible setup for building automated
 tests in Java. It combines Spring Boot for dependency management, JUnit 5 for
-testing, and optional Appium integration for mobile automation. The framework
-contains examples of page objects, REST clients, custom JUnit extensions and
-configuration classes.
+testing, and optional Appium and Selenium integrations for mobile and web
+automation. The framework contains examples of page objects, REST clients,
+custom JUnit extensions and configuration classes.
 
 ## Project Structure
 
@@ -50,11 +50,20 @@ mvn test -Dspring.profiles.active=appium
 
 Profiles can also be set in `src/main/resources/application.properties`.
 
+To execute browser based tests through Selenium use the `selenium` profile:
+
+```bash
+mvn test -Dspring.profiles.active=selenium
+```
+Configuration for a remote Selenium server can be provided in
+`src/main/resources/selenium.properties` via `selenium.remote-host` and
+`selenium.remote-port` settings.
+
 ### Start Writing Your Own Tests
 
 1. **Choose a profile** – keep the default `mock` profile while developing
-   framework pieces, then switch to `appium` (or another custom profile) when a
-   real device is available.
+   framework pieces, then switch to `appium`, `selenium` or another custom
+   profile when real infrastructure is available.
 2. **Create page objects** – add classes under
    `src/main/java/com/example/aqa/app/client` returning `AppObject` instances for
    the screens you want to exercise.
@@ -72,7 +81,8 @@ between environments as simple as changing the active profile.
 
 - Implement your own `AppDriver` to integrate with Appium, Selenium or another
   automation tool.
-- Enable the beans in `AppiumConfiguration` to connect to a real Appium server.
+- Enable the beans in `AppiumConfiguration` or `SeleniumConfiguration` to
+  connect to a real device or browser.
 - Add additional page objects, API clients or JUnit extensions as needed.
 
 ## License

--- a/pom.xml
+++ b/pom.xml
@@ -103,11 +103,16 @@
 			<version>${jackson-databind.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>selenium-java</artifactId>
-			<version>${selenium.version}</version>
-		</dependency>
+                <dependency>
+                        <groupId>org.seleniumhq.selenium</groupId>
+                        <artifactId>selenium-remote-driver</artifactId>
+                        <version>${selenium.version}</version>
+                </dependency>
+                <dependency>
+                        <groupId>org.seleniumhq.selenium</groupId>
+                        <artifactId>selenium-chrome-driver</artifactId>
+                        <version>${selenium.version}</version>
+                </dependency>
         </dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,126 +1,133 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
-		<relativePath/>
-	</parent>
-	<groupId>com.example</groupId>
-	<artifactId>template</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name>Test Automation framework template</name>
-	<description>Test Automation framework template</description>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.4</version>
+        <relativePath/>
+    </parent>
+    <groupId>com.example</groupId>
+    <artifactId>template</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>Test Automation framework template</name>
+    <description>Test Automation framework template</description>
 
-	<properties>
-		<java.version>21</java.version>
-		<junit-jupiter.version>5.13.4</junit-jupiter.version>
-		<appium.java-client.version>9.5.0</appium.java-client.version>
-		<lombok.version>1.18.38</lombok.version>
-		<rest-assured.version>5.5.5</rest-assured.version>
-		<assertj-core.version>3.27.3</assertj-core.version>
-		<awaitility.version>4.3.0</awaitility.version>
-		<jackson-databind.version>2.19.2</jackson-databind.version>
-		<selenium.version>4.21.0</selenium.version>
-	</properties>
-	<dependencies>
+    <properties>
+        <java.version>21</java.version>
+        <junit-jupiter.version>5.13.4</junit-jupiter.version>
+        <appium.java-client.version>9.5.0</appium.java-client.version>
+        <lombok.version>1.18.38</lombok.version>
+        <rest-assured.version>5.5.5</rest-assured.version>
+        <assertj-core.version>3.27.3</assertj-core.version>
+        <awaitility.version>4.3.0</awaitility.version>
+        <jackson-databind.version>2.19.2</jackson-databind.version>
+        <selenium.version>4.21.0</selenium.version>
+    </properties>
+    <dependencies>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit-jupiter.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.appium</groupId>
+            <artifactId>java-client</artifactId>
+            <version>${appium.java-client.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>${rest-assured.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj-core.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson-databind.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-remote-driver</artifactId>
+            <version>${selenium.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-chrome-driver</artifactId>
+            <version>${selenium.version}</version>
+        </dependency>
 
 		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-context</artifactId>
+			<groupId>org.seleniumhq.selenium</groupId>
+			<artifactId>selenium-firefox-driver</artifactId>
+			<version>${selenium.version}</version>
 		</dependency>
+    </dependencies>
 
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-test</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-test</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.retry</groupId>
-			<artifactId>spring-retry</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-classic</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<version>${junit-jupiter.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>io.appium</groupId>
-			<artifactId>java-client</artifactId>
-			<version>${appium.java-client.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>${lombok.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>io.rest-assured</groupId>
-			<artifactId>rest-assured</artifactId>
-			<version>${rest-assured.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-core</artifactId>
-			<version>${assertj-core.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.awaitility</groupId>
-			<artifactId>awaitility</artifactId>
-			<version>${awaitility.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<version>${jackson-databind.version}</version>
-		</dependency>
-
-                <dependency>
-                        <groupId>org.seleniumhq.selenium</groupId>
-                        <artifactId>selenium-remote-driver</artifactId>
-                        <version>${selenium.version}</version>
-                </dependency>
-                <dependency>
-                        <groupId>org.seleniumhq.selenium</groupId>
-                        <artifactId>selenium-chrome-driver</artifactId>
-                        <version>${selenium.version}</version>
-                </dependency>
-        </dependencies>
-
-	<build>
-		<plugins>
-			<plugin>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>${maven-surefire-plugin.version}</version>
-			</plugin>
-		</plugins>
-	</build>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
 		<assertj-core.version>3.27.3</assertj-core.version>
 		<awaitility.version>4.3.0</awaitility.version>
 		<jackson-databind.version>2.19.2</jackson-databind.version>
+		<selenium.version>4.21.0</selenium.version>
 	</properties>
 	<dependencies>
 
@@ -101,7 +102,13 @@
 			<artifactId>jackson-databind</artifactId>
 			<version>${jackson-databind.version}</version>
 		</dependency>
-	</dependencies>
+
+		<dependency>
+			<groupId>org.seleniumhq.selenium</groupId>
+			<artifactId>selenium-java</artifactId>
+			<version>${selenium.version}</version>
+		</dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/example/aqa/configuration/MainConfiguration.java
+++ b/src/main/java/com/example/aqa/configuration/MainConfiguration.java
@@ -3,10 +3,13 @@ package com.example.aqa.configuration;
 import com.example.aqa.configuration.extension.ExtensionConfiguration;
 import com.example.aqa.configuration.rest.RestApiClientConfiguration;
 import com.example.aqa.configuration.driver.appium.AppiumConfiguration;
+import com.example.aqa.configuration.driver.selenium.SeleniumConfiguration;
 import com.example.aqa.driver.AppDriver;
 import com.example.aqa.driver.AppiumBasedAppDriver;
 import com.example.aqa.driver.MockAppDriver;
+import com.example.aqa.driver.SeleniumBasedAppDriver;
 import io.appium.java_client.AppiumDriver;
+import org.openqa.selenium.WebDriver;
 import org.springframework.context.annotation.*;
 
 /**
@@ -23,6 +26,7 @@ import org.springframework.context.annotation.*;
 @ComponentScan(basePackages = "com.example.aqa")
 @Import({
         AppiumConfiguration.class,
+        SeleniumConfiguration.class,
         RestApiClientConfiguration.class,
         ExtensionConfiguration.class
 })
@@ -60,6 +64,22 @@ public class MainConfiguration {
     @Profile("appium")
     public AppDriver appiumBasedAppDriver(AppiumDriver appiumDriver) {
         return new AppiumBasedAppDriver(appiumDriver);
+    }
+
+    /**
+     * Provides the {@link AppDriver} used in tests when running with Selenium.
+     * <p>
+     * Activating the {@code selenium} profile enables browser based testing
+     * without altering test code. This bean adapts the raw {@link WebDriver}
+     * into the framework's {@link AppDriver} abstraction.
+     *
+     * @param webDriver the Selenium driver instance
+     * @return Selenium-based implementation of the application driver
+     */
+    @Bean
+    @Profile("selenium")
+    public AppDriver seleniumBasedAppDriver(WebDriver webDriver) {
+        return new SeleniumBasedAppDriver(webDriver);
     }
 
 }

--- a/src/main/java/com/example/aqa/configuration/driver/appium/AppiumProperties.java
+++ b/src/main/java/com/example/aqa/configuration/driver/appium/AppiumProperties.java
@@ -23,7 +23,7 @@ public class AppiumProperties {
     private String host;
 
     /** Appium server port. */
-    private int port;
+    private Integer port;
 
     /** Device name for the session. */
     private String device;

--- a/src/main/java/com/example/aqa/configuration/driver/selenium/SeleniumConfiguration.java
+++ b/src/main/java/com/example/aqa/configuration/driver/selenium/SeleniumConfiguration.java
@@ -1,0 +1,48 @@
+package com.example.aqa.configuration.driver.selenium;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+/**
+ * Configuration that wires a {@link WebDriver} when the {@code selenium} profile is active.
+ * <p>
+ * Keeping Selenium-specific beans behind a profile allows the rest of the
+ * framework to run without a browser. Once enabled this configuration creates
+ * a {@link WebDriver} either locally or by connecting to a remote Selenium server.
+ */
+@Profile("selenium")
+@Configuration
+@EnableConfigurationProperties(SeleniumProperties.class)
+public class SeleniumConfiguration {
+
+    /**
+     * Creates the {@link WebDriver} instance.
+     * <p>
+     * If remote host and port are provided, the driver connects to that Selenium Grid,
+     * otherwise a local {@link ChromeDriver} is started.
+     *
+     * @param properties Selenium configuration properties
+     * @return configured WebDriver
+     * @throws URISyntaxException    if the remote URI cannot be constructed
+     * @throws MalformedURLException if the remote URL is invalid
+     */
+    @Bean(destroyMethod = "quit")
+    public WebDriver webDriver(SeleniumProperties properties) throws URISyntaxException, MalformedURLException {
+        if (properties.getRemoteHost() != null && !properties.getRemoteHost().isBlank()) {
+            URI remoteUri = new URI("http", null, properties.getRemoteHost(), properties.getRemotePort(), null, null, null);
+            return new RemoteWebDriver(remoteUri.toURL(), new ChromeOptions());
+        }
+        return new ChromeDriver();
+    }
+}

--- a/src/main/java/com/example/aqa/configuration/driver/selenium/SeleniumConfiguration.java
+++ b/src/main/java/com/example/aqa/configuration/driver/selenium/SeleniumConfiguration.java
@@ -3,6 +3,7 @@ package com.example.aqa.configuration.driver.selenium;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxDriver;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,7 +24,7 @@ public class SeleniumConfiguration {
 
     @Profile("chrome")
     @Bean
-    public ChromeOptions options() {
+    public ChromeOptions chromeOptions() {
         return new ChromeOptions().addArguments("--disable-search-engine-choice-screen");
     }
 
@@ -37,14 +38,33 @@ public class SeleniumConfiguration {
      */
     @Profile("chrome")
     @Bean(destroyMethod = "quit")
-    public WebDriver webDriver(SeleniumProperties properties, ChromeOptions options) {
-
+    public WebDriver chromeDriver(SeleniumProperties properties, ChromeOptions options) {
         var driver = new ChromeDriver(options);
-        if (properties.getHost() != null) {
-            driver.navigate().to(String.format("%s:%d", properties.getHost(), properties.getPort()));
-        } else {
-            driver.navigate().to(properties.getHost());
-        }
+        navigateAppStartPage(properties, driver);
         return driver;
+    }
+
+    /**
+     * Creates the {@link WebDriver} instance.
+     * <p>
+     * Local {@link FirefoxDriver}
+     *
+     * @param properties Selenium configuration properties
+     * @return configured WebDriver
+     */
+    @Profile("firefox")
+    @Bean(destroyMethod = "quit")
+    public WebDriver firefox(SeleniumProperties properties) {
+        var driver = new FirefoxDriver();
+        navigateAppStartPage(properties, driver);
+        return driver;
+    }
+
+    private static void navigateAppStartPage(SeleniumProperties properties, WebDriver driver) {
+        if (properties.getAppPort() != null) {
+            driver.navigate().to(String.format("%s:%d", properties.getAppHost(), properties.getAppPort()));
+        } else {
+            driver.navigate().to(properties.getAppHost());
+        }
     }
 }

--- a/src/main/java/com/example/aqa/configuration/driver/selenium/SeleniumConfiguration.java
+++ b/src/main/java/com/example/aqa/configuration/driver/selenium/SeleniumConfiguration.java
@@ -3,46 +3,48 @@ package com.example.aqa.configuration.driver.selenium;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.remote.RemoteWebDriver;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
 
 /**
  * Configuration that wires a {@link WebDriver} when the {@code selenium} profile is active.
  * <p>
  * Keeping Selenium-specific beans behind a profile allows the rest of the
  * framework to run without a browser. Once enabled this configuration creates
- * a {@link WebDriver} either locally or by connecting to a remote Selenium server.
+ * a {@link WebDriver} either locally.
  */
 @Profile("selenium")
 @Configuration
 @EnableConfigurationProperties(SeleniumProperties.class)
 public class SeleniumConfiguration {
 
+
+    @Profile("chrome")
+    @Bean
+    public ChromeOptions options() {
+        return new ChromeOptions().addArguments("--disable-search-engine-choice-screen");
+    }
+
     /**
      * Creates the {@link WebDriver} instance.
      * <p>
-     * If remote host and port are provided, the driver connects to that Selenium Grid,
-     * otherwise a local {@link ChromeDriver} is started.
+     * Local {@link ChromeDriver}
      *
      * @param properties Selenium configuration properties
      * @return configured WebDriver
-     * @throws URISyntaxException    if the remote URI cannot be constructed
-     * @throws MalformedURLException if the remote URL is invalid
      */
+    @Profile("chrome")
     @Bean(destroyMethod = "quit")
-    public WebDriver webDriver(SeleniumProperties properties) throws URISyntaxException, MalformedURLException {
-        if (properties.getRemoteHost() != null && !properties.getRemoteHost().isBlank()) {
-            URI remoteUri = new URI("http", null, properties.getRemoteHost(), properties.getRemotePort(), null, null, null);
-            return new RemoteWebDriver(remoteUri.toURL(), new ChromeOptions());
+    public WebDriver webDriver(SeleniumProperties properties, ChromeOptions options) {
+
+        var driver = new ChromeDriver(options);
+        if (properties.getHost() != null) {
+            driver.navigate().to(String.format("%s:%d", properties.getHost(), properties.getPort()));
+        } else {
+            driver.navigate().to(properties.getHost());
         }
-        return new ChromeDriver();
+        return driver;
     }
 }

--- a/src/main/java/com/example/aqa/configuration/driver/selenium/SeleniumProperties.java
+++ b/src/main/java/com/example/aqa/configuration/driver/selenium/SeleniumProperties.java
@@ -18,9 +18,9 @@ import org.springframework.context.annotation.PropertySource;
 @Data
 public class SeleniumProperties {
 
-    /** Host name of the remote Selenium server (e.g. Selenium Grid). */
-    private String host;
+    /** Host name of the app */
+    private String appHost;
 
-    /** Port of the remote Selenium server. */
-    private Integer port;
+    /** Port of the app. */
+    private Integer appPort;
 }

--- a/src/main/java/com/example/aqa/configuration/driver/selenium/SeleniumProperties.java
+++ b/src/main/java/com/example/aqa/configuration/driver/selenium/SeleniumProperties.java
@@ -1,0 +1,26 @@
+package com.example.aqa.configuration.driver.selenium;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.PropertySource;
+
+/**
+ * Properties for configuring a Selenium server connection.
+ * <p>
+ * Externalising Selenium specific settings keeps the framework flexible and
+ * allows contributors to provide their own <code>selenium.properties</code>
+ * without touching source code.
+ */
+@PropertySource("classpath:selenium.properties")
+@ConfigurationProperties(prefix = "selenium")
+@ConfigurationPropertiesScan
+@Data
+public class SeleniumProperties {
+
+    /** Host name of the remote Selenium server (e.g. Selenium Grid). */
+    private String remoteHost;
+
+    /** Port of the remote Selenium server. */
+    private int remotePort;
+}

--- a/src/main/java/com/example/aqa/configuration/driver/selenium/SeleniumProperties.java
+++ b/src/main/java/com/example/aqa/configuration/driver/selenium/SeleniumProperties.java
@@ -19,8 +19,8 @@ import org.springframework.context.annotation.PropertySource;
 public class SeleniumProperties {
 
     /** Host name of the remote Selenium server (e.g. Selenium Grid). */
-    private String remoteHost;
+    private String host;
 
     /** Port of the remote Selenium server. */
-    private int remotePort;
+    private Integer port;
 }

--- a/src/main/java/com/example/aqa/driver/SeleniumBasedAppDriver.java
+++ b/src/main/java/com/example/aqa/driver/SeleniumBasedAppDriver.java
@@ -1,0 +1,55 @@
+package com.example.aqa.driver;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
+
+/**
+ * {@link AppDriver} implementation backed by Selenium's {@link WebDriver}.
+ * <p>
+ * The implementation deliberately mirrors {@link AppiumBasedAppDriver} to keep the
+ * examples consistent across different technologies. Tests interact with the
+ * {@link AppDriver} interface while this class handles low level WebDriver
+ * calls.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class SeleniumBasedAppDriver implements AppDriver {
+
+    /** Underlying Selenium driver executing commands in a browser. */
+    private final WebDriver webDriver;
+
+    /** {@inheritDoc} */
+    @Override
+    public void click(String locator) {
+        log.info("Clicking on element with locator: {} by selenium driver", locator);
+        webDriver.findElement(By.xpath(locator)).click();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getText(String locator) {
+        log.info("Getting text from element with locator: {} by selenium driver", locator);
+        return webDriver.findElement(By.xpath(locator)).getText();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void sendText(String locator, String text) {
+        log.info("Sending text '{}' to element with locator: {} by selenium driver", text, locator);
+        webDriver.findElement(By.xpath(locator)).sendKeys(text);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void waitObject(String locator) {
+        log.info("Waiting for element with locator: {} by selenium driver", locator);
+        new WebDriverWait(webDriver, Duration.ofSeconds(10))
+                .until(ExpectedConditions.visibilityOfElementLocated(By.xpath(locator)));
+    }
+}

--- a/src/main/resources/appium.properties
+++ b/src/main/resources/appium.properties
@@ -2,4 +2,4 @@ appium.host=http://127.0.0.1
 appium.port=4723
 appium.device=android
 appium.app=PATH TO YOUR APP
-appium.timeOut=2
+appium.time-out=2

--- a/src/main/resources/selenium.properties
+++ b/src/main/resources/selenium.properties
@@ -1,0 +1,3 @@
+# Selenium server configuration
+selenium.remote-host=localhost
+selenium.remote-port=4444

--- a/src/main/resources/selenium.properties
+++ b/src/main/resources/selenium.properties
@@ -1,3 +1,2 @@
-# Selenium server configuration
-selenium.remote-host=localhost
-selenium.remote-port=4444
+selenium.app-host=localhost
+selenium.app-port=1234


### PR DESCRIPTION
## Summary
- add selenium-based driver implementation
- configure selenium beans and properties behind a new `selenium` profile
- document profile usage in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b0aaa6dd48326a5c99ecda1a5b0ed