### PR TITLE
feat: add browser-specific selenium profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This project demonstrates a minimal yet extensible setup for building automated
 tests in Java. It combines Spring Boot for dependency management, JUnit 5 for
-testing, and optional Appium integration for mobile automation. The framework
-contains examples of page objects, REST clients, custom JUnit extensions and
-configuration classes.
+testing, and optional Appium and Selenium integrations for mobile and web
+automation. The framework contains examples of page objects, REST clients,
+custom JUnit extensions and configuration classes.
 
 ## Project Structure
 
@@ -50,11 +50,25 @@ mvn test -Dspring.profiles.active=appium
 
 Profiles can also be set in `src/main/resources/application.properties`.
 
+To execute browser based tests through Selenium use the `selenium` profile
+along with a browser-specific profile:
+
+```bash
+# run tests in Google Chrome
+mvn test -Dspring.profiles.active=selenium,chrome
+
+# run tests in Mozilla Firefox
+mvn test -Dspring.profiles.active=selenium,firefox
+```
+The framework relies on local browser drivers, so ensure the corresponding
+`chromedriver` or `geckodriver` executable is available on your system `PATH`.
+
 ### Start Writing Your Own Tests
 
 1. **Choose a profile** – keep the default `mock` profile while developing
-   framework pieces, then switch to `appium` (or another custom profile) when a
-   real device is available.
+   framework pieces, then switch to `appium`, `selenium,chrome`,
+   `selenium,firefox` or another custom profile when real infrastructure is
+   available.
 2. **Create page objects** – add classes under
    `src/main/java/com/example/aqa/app/client` returning `AppObject` instances for
    the screens you want to exercise.
@@ -72,7 +86,8 @@ between environments as simple as changing the active profile.
 
 - Implement your own `AppDriver` to integrate with Appium, Selenium or another
   automation tool.
-- Enable the beans in `AppiumConfiguration` to connect to a real Appium server.
+- Enable the beans in `AppiumConfiguration` or `SeleniumConfiguration` to
+  connect to a real device or browser.
 - Add additional page objects, API clients or JUnit extensions as needed.
 
 ## License

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
 		<assertj-core.version>3.27.3</assertj-core.version>
 		<awaitility.version>4.3.0</awaitility.version>
 		<jackson-databind.version>2.19.2</jackson-databind.version>
+		<selenium.version>4.21.0</selenium.version>
 	</properties>
 	<dependencies>
 
@@ -101,7 +102,23 @@
 			<artifactId>jackson-databind</artifactId>
 			<version>${jackson-databind.version}</version>
 		</dependency>
-	</dependencies>
+
+                <dependency>
+                        <groupId>org.seleniumhq.selenium</groupId>
+                        <artifactId>selenium-remote-driver</artifactId>
+                        <version>${selenium.version}</version>
+                </dependency>
+                <dependency>
+                        <groupId>org.seleniumhq.selenium</groupId>
+                        <artifactId>selenium-chrome-driver</artifactId>
+                        <version>${selenium.version}</version>
+                </dependency>
+                <dependency>
+                        <groupId>org.seleniumhq.selenium</groupId>
+                        <artifactId>selenium-firefox-driver</artifactId>
+                        <version>${selenium.version}</version>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/example/aqa/configuration/MainConfiguration.java
+++ b/src/main/java/com/example/aqa/configuration/MainConfiguration.java
@@ -3,10 +3,13 @@ package com.example.aqa.configuration;
 import com.example.aqa.configuration.extension.ExtensionConfiguration;
 import com.example.aqa.configuration.rest.RestApiClientConfiguration;
 import com.example.aqa.configuration.driver.appium.AppiumConfiguration;
+import com.example.aqa.configuration.driver.selenium.SeleniumConfiguration;
 import com.example.aqa.driver.AppDriver;
 import com.example.aqa.driver.AppiumBasedAppDriver;
 import com.example.aqa.driver.MockAppDriver;
+import com.example.aqa.driver.SeleniumBasedAppDriver;
 import io.appium.java_client.AppiumDriver;
+import org.openqa.selenium.WebDriver;
 import org.springframework.context.annotation.*;
 
 /**
@@ -23,6 +26,7 @@ import org.springframework.context.annotation.*;
 @ComponentScan(basePackages = "com.example.aqa")
 @Import({
         AppiumConfiguration.class,
+        SeleniumConfiguration.class,
         RestApiClientConfiguration.class,
         ExtensionConfiguration.class
 })
@@ -60,6 +64,24 @@ public class MainConfiguration {
     @Profile("appium")
     public AppDriver appiumBasedAppDriver(AppiumDriver appiumDriver) {
         return new AppiumBasedAppDriver(appiumDriver);
+    }
+
+    /**
+     * Provides the {@link AppDriver} used in tests when running with Selenium.
+     * <p>
+     * Activating the {@code selenium} profile enables browser based testing
+     * without altering test code. A second profile such as {@code chrome} or
+     * {@code firefox} must also be active to select the concrete browser
+     * implementation. This bean adapts the raw {@link WebDriver} into the
+     * framework's {@link AppDriver} abstraction.
+     *
+     * @param webDriver the Selenium driver instance
+     * @return Selenium-based implementation of the application driver
+     */
+    @Bean
+    @Profile("selenium")
+    public AppDriver seleniumBasedAppDriver(WebDriver webDriver) {
+        return new SeleniumBasedAppDriver(webDriver);
     }
 
 }

--- a/src/main/java/com/example/aqa/configuration/driver/selenium/SeleniumConfiguration.java
+++ b/src/main/java/com/example/aqa/configuration/driver/selenium/SeleniumConfiguration.java
@@ -1,0 +1,45 @@
+package com.example.aqa.configuration.driver.selenium;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * Selenium driver configuration that exposes a local {@link WebDriver} when
+ * the {@code selenium} profile is active.
+ * <p>
+ * To select a concrete browser activate an additional profile. For example,
+ * run tests with {@code -Dspring.profiles.active=selenium,chrome} to control
+ * Google Chrome or replace {@code chrome} with {@code firefox} to start
+ * Mozilla Firefox. Keeping browsers behind profiles lets the framework stay
+ * lightweight while still allowing browser-specific execution.
+ */
+@Profile("selenium")
+@Configuration
+public class SeleniumConfiguration {
+
+    /**
+     * Creates a {@link ChromeDriver} when the {@code chrome} profile is active.
+     *
+     * @return WebDriver controlling Google Chrome
+     */
+    @Bean(destroyMethod = "quit")
+    @Profile("chrome")
+    public WebDriver chromeDriver() {
+        return new ChromeDriver();
+    }
+
+    /**
+     * Creates a {@link FirefoxDriver} when the {@code firefox} profile is active.
+     *
+     * @return WebDriver controlling Mozilla Firefox
+     */
+    @Bean(destroyMethod = "quit")
+    @Profile("firefox")
+    public WebDriver firefoxDriver() {
+        return new FirefoxDriver();
+    }
+}

--- a/src/main/java/com/example/aqa/driver/SeleniumBasedAppDriver.java
+++ b/src/main/java/com/example/aqa/driver/SeleniumBasedAppDriver.java
@@ -1,0 +1,56 @@
+package com.example.aqa.driver;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
+
+/**
+ * {@link AppDriver} implementation backed by Selenium's {@link WebDriver}.
+ * <p>
+ * The implementation deliberately mirrors {@link AppiumBasedAppDriver} to keep the
+ * examples consistent across different technologies. Tests interact with the
+ * {@link AppDriver} interface while this class handles low level WebDriver
+ * calls. The concrete browser driver (Chrome or Firefox) is supplied by Spring
+ * based on the active profile.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class SeleniumBasedAppDriver implements AppDriver {
+
+    /** Underlying Selenium driver executing commands in a browser. */
+    private final WebDriver webDriver;
+
+    /** {@inheritDoc} */
+    @Override
+    public void click(String locator) {
+        log.info("Clicking on element with locator: {} by selenium driver", locator);
+        webDriver.findElement(By.xpath(locator)).click();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getText(String locator) {
+        log.info("Getting text from element with locator: {} by selenium driver", locator);
+        return webDriver.findElement(By.xpath(locator)).getText();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void sendText(String locator, String text) {
+        log.info("Sending text '{}' to element with locator: {} by selenium driver", text, locator);
+        webDriver.findElement(By.xpath(locator)).sendKeys(text);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void waitObject(String locator) {
+        log.info("Waiting for element with locator: {} by selenium driver", locator);
+        new WebDriverWait(webDriver, Duration.ofSeconds(10))
+                .until(ExpectedConditions.visibilityOfElementLocated(By.xpath(locator)));
+    }
+}


### PR DESCRIPTION
## Summary
- provide local Selenium driver beans for Chrome and Firefox behind dedicated Spring profiles
- add Firefox driver dependency and refine Spring configuration and docs for browser selection

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b0aaa6dd48326a5c99ecda1a5b0ed