### PR TITLE
feat: add Playwright browser driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,24 @@ selenium.grid-host=http://127.0.0.1
 selenium.grid-port=4444
 ```
 
+### `playwright.properties`
+
+Settings used when Playwright profiles are active:
+
+- `playwright.app-host` / `playwright.app-port` – address of the web application
+  under test.
+- `playwright.grid-host` / `playwright.grid-port` – remote debugging endpoint
+  when connecting to an existing Chromium instance.
+
+Example:
+
+```properties
+playwright.app-host=localhost
+playwright.app-port=1234
+playwright.grid-host=http://127.0.0.1
+playwright.grid-port=9222
+```
+
 ### `appium.properties`
 
 Settings used with the `appium` profile:
@@ -160,6 +178,17 @@ The browser automatically navigates to the application host defined in
 optional `selenium.app-port` settings. When running against a Selenium Grid the
 grid connection details are read from `selenium.grid-host` and
 `selenium.grid-port`.
+
+To execute browser based tests with Playwright choose the browser and whether
+it should run locally or connect to an existing Chromium instance:
+
+```bash
+# run Chromium locally
+mvn test -Dspring.profiles.active="playwright,chromium-local"
+
+# connect to a remote Chromium instance
+mvn test -Dspring.profiles.active="playwright,chromium-remote"
+```
 
 ### Start Writing Your Own Tests
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ example:
 ```properties
 spring.profiles.active=selenium,chrome-remote  # run against a Selenium Grid
 spring.profiles.active=appium                  # execute tests via Appium
+spring.profiles.active=playwright,chrome-local # run via Playwright locally
 ```
 
 You can override this value on the command line with
@@ -69,10 +70,11 @@ selenium.grid-port=4444
 
 Settings used when Playwright profiles are active:
 
-- `playwright.app-host` / `playwright.app-port` – address of the web application
-  under test.
+- `playwright.app-host` / `playwright.app-port` – address of the web
+  application under test. Required for both local and remote sessions.
 - `playwright.grid-host` / `playwright.grid-port` – remote debugging endpoint
-  when connecting to an existing Chromium instance.
+  when connecting to an existing Chrome instance. Omit when running Chrome
+  locally.
 
 Example:
 
@@ -180,14 +182,16 @@ grid connection details are read from `selenium.grid-host` and
 `selenium.grid-port`.
 
 To execute browser based tests with Playwright choose the browser and whether
-it should run locally or connect to an existing Chromium instance:
+it should run locally or connect to an existing Chrome instance. Ensure
+`src/main/resources/playwright.properties` points to your application and, for
+remote sessions, to the Chrome debugging endpoint:
 
 ```bash
-# run Chromium locally
-mvn test -Dspring.profiles.active="playwright,chromium-local"
+# run Chrome locally
+mvn test -Dspring.profiles.active="playwright,chrome-local"
 
-# connect to a remote Chromium instance
-mvn test -Dspring.profiles.active="playwright,chromium-remote"
+# connect to a remote Chrome instance
+mvn test -Dspring.profiles.active="playwright,chrome-remote"
 ```
 
 ### Start Writing Your Own Tests

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <awaitility.version>4.3.0</awaitility.version>
         <jackson-databind.version>2.19.2</jackson-databind.version>
         <selenium.version>4.21.0</selenium.version>
+        <playwright.version>1.48.0</playwright.version>
     </properties>
     <dependencies>
 
@@ -115,11 +116,17 @@
             <version>${selenium.version}</version>
         </dependency>
 
-		<dependency>
-			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>selenium-firefox-driver</artifactId>
-			<version>${selenium.version}</version>
-		</dependency>
+                <dependency>
+                        <groupId>org.seleniumhq.selenium</groupId>
+                        <artifactId>selenium-firefox-driver</artifactId>
+                        <version>${selenium.version}</version>
+                </dependency>
+
+        <dependency>
+            <groupId>com.microsoft.playwright</groupId>
+            <artifactId>playwright</artifactId>
+            <version>${playwright.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/example/aqa/configuration/MainConfiguration.java
+++ b/src/main/java/com/example/aqa/configuration/MainConfiguration.java
@@ -3,6 +3,7 @@ package com.example.aqa.configuration;
 import com.example.aqa.configuration.common.CommonConfiguration;
 import com.example.aqa.configuration.driver.selenium.SeleniumChromeConfiguration;
 import com.example.aqa.configuration.driver.selenium.SeleniumFireFoxConfiguration;
+import com.example.aqa.configuration.driver.playwright.PlaywrightChromiumConfiguration;
 import com.example.aqa.configuration.driver.waiter.WebDriverWaitConfiguration;
 import com.example.aqa.configuration.extension.ExtensionConfiguration;
 import com.example.aqa.configuration.rest.RestApiClientConfiguration;
@@ -11,6 +12,8 @@ import com.example.aqa.driver.AppDriver;
 import com.example.aqa.driver.AppiumBasedAppDriver;
 import com.example.aqa.driver.MockAppDriver;
 import com.example.aqa.driver.SeleniumBasedAppDriver;
+import com.example.aqa.driver.PlaywrightBasedAppDriver;
+import com.microsoft.playwright.Page;
 import io.appium.java_client.AppiumDriver;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -33,6 +36,7 @@ import org.springframework.context.annotation.*;
         AppiumConfiguration.class,
         SeleniumChromeConfiguration.class,
         SeleniumFireFoxConfiguration.class,
+        PlaywrightChromiumConfiguration.class,
         WebDriverWaitConfiguration.class,
         RestApiClientConfiguration.class,
         ExtensionConfiguration.class,
@@ -88,6 +92,22 @@ public class MainConfiguration {
     @Profile("selenium")
     public AppDriver seleniumBasedAppDriver(WebDriver webDriver, WebDriverWait webDriverWait) {
         return new SeleniumBasedAppDriver(webDriver, webDriverWait);
+    }
+
+    /**
+     * Provides the {@link AppDriver} used in tests when running with Playwright.
+     * <p>
+     * Activating the {@code playwright} profile enables browser automation via
+     * Playwright without altering test code. This bean adapts the Playwright
+     * {@link Page} into the framework's {@link AppDriver} abstraction.
+     *
+     * @param page the Playwright page instance
+     * @return Playwright-based implementation of the application driver
+     */
+    @Bean
+    @Profile("playwright")
+    public AppDriver playwrightBasedAppDriver(Page page) {
+        return new PlaywrightBasedAppDriver(page);
     }
 
 }

--- a/src/main/java/com/example/aqa/configuration/driver/playwright/PlaywrightChromiumConfiguration.java
+++ b/src/main/java/com/example/aqa/configuration/driver/playwright/PlaywrightChromiumConfiguration.java
@@ -15,7 +15,7 @@ import java.net.URISyntaxException;
  * Spring configuration wiring Playwright Chromium {@link Page} instances.
  * <p>
  * The configuration is activated when the {@code playwright} profile is enabled.
- * Additional profiles {@code chromium-local} or {@code chromium-remote} decide
+ * Additional profiles {@code chrome-local} or {@code chrome-remote} decide
  * whether the browser runs locally or connects to a remote endpoint.
  */
 @Profile({"playwright"})
@@ -41,7 +41,7 @@ public class PlaywrightChromiumConfiguration {
      * @return remote page
      * @throws URISyntaxException if the endpoint URI is invalid
      */
-    @Profile("chromium-remote")
+    @Profile("chrome-remote")
     @Bean(destroyMethod = "close")
     public Page remoteChromiumPage(PlaywrightProperties properties, BrowserType.LaunchOptions options)
             throws URISyntaxException {
@@ -59,7 +59,7 @@ public class PlaywrightChromiumConfiguration {
      * @param options    launch options
      * @return local page
      */
-    @Profile("chromium-local")
+    @Profile("chrome-local")
     @Bean(destroyMethod = "close")
     public Page localChromiumPage(PlaywrightProperties properties, BrowserType.LaunchOptions options) {
         var playwright = Playwright.create();

--- a/src/main/java/com/example/aqa/configuration/driver/playwright/PlaywrightChromiumConfiguration.java
+++ b/src/main/java/com/example/aqa/configuration/driver/playwright/PlaywrightChromiumConfiguration.java
@@ -1,0 +1,86 @@
+package com.example.aqa.configuration.driver.playwright;
+
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Spring configuration wiring Playwright Chromium {@link Page} instances.
+ * <p>
+ * The configuration is activated when the {@code playwright} profile is enabled.
+ * Additional profiles {@code chromium-local} or {@code chromium-remote} decide
+ * whether the browser runs locally or connects to a remote endpoint.
+ */
+@Profile({"playwright"})
+@Configuration
+@EnableConfigurationProperties(PlaywrightProperties.class)
+public class PlaywrightChromiumConfiguration {
+
+    /**
+     * Provides default {@link BrowserType.LaunchOptions} for Chromium sessions.
+     *
+     * @return configured launch options
+     */
+    @Bean
+    public BrowserType.LaunchOptions chromiumLaunchOptions() {
+        return new BrowserType.LaunchOptions();
+    }
+
+    /**
+     * Creates a {@link Page} connected to a remote Chromium instance.
+     *
+     * @param properties Playwright connection properties
+     * @param options    launch options
+     * @return remote page
+     * @throws URISyntaxException if the endpoint URI is invalid
+     */
+    @Profile("chromium-remote")
+    @Bean(destroyMethod = "close")
+    public Page remoteChromiumPage(PlaywrightProperties properties, BrowserType.LaunchOptions options)
+            throws URISyntaxException {
+        var playwright = Playwright.create();
+        var browser = playwright.chromium().connectOverCDP(new URI(String.format("%s:%d", properties.getGridHost(), properties.getGridPort())).toString());
+        var page = browser.newPage();
+        navigateAppStartPage(properties, page);
+        return page;
+    }
+
+    /**
+     * Creates a local {@link Page} using Chromium.
+     *
+     * @param properties Playwright connection properties
+     * @param options    launch options
+     * @return local page
+     */
+    @Profile("chromium-local")
+    @Bean(destroyMethod = "close")
+    public Page localChromiumPage(PlaywrightProperties properties, BrowserType.LaunchOptions options) {
+        var playwright = Playwright.create();
+        var browser = playwright.chromium().launch(options);
+        var page = browser.newPage();
+        navigateAppStartPage(properties, page);
+        return page;
+    }
+
+    /**
+     * Navigates the provided page to the application start page.
+     *
+     * @param properties Playwright connection properties
+     * @param page       page to navigate
+     */
+    private static void navigateAppStartPage(PlaywrightProperties properties, Page page) {
+        if (properties.getAppPort() != null) {
+            page.navigate(String.format("%s:%d", properties.getAppHost(), properties.getAppPort()));
+        } else {
+            page.navigate(properties.getAppHost());
+        }
+    }
+}
+

--- a/src/main/java/com/example/aqa/configuration/driver/playwright/PlaywrightProperties.java
+++ b/src/main/java/com/example/aqa/configuration/driver/playwright/PlaywrightProperties.java
@@ -1,0 +1,33 @@
+package com.example.aqa.configuration.driver.playwright;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.PropertySource;
+
+/**
+ * Properties for configuring a Playwright browser connection.
+ * <p>
+ * Externalising Playwright specific settings keeps the framework flexible and
+ * allows contributors to provide their own <code>playwright.properties</code>
+ * without touching source code.
+ */
+@PropertySource("classpath:playwright.properties")
+@ConfigurationProperties(prefix = "playwright")
+@ConfigurationPropertiesScan
+@Data
+public class PlaywrightProperties {
+
+    /** Host of the application under test. */
+    private String appHost;
+
+    /** Port of the application under test. */
+    private Integer appPort;
+
+    /** Host of the remote browser endpoint. */
+    private String gridHost;
+
+    /** Port of the remote browser endpoint. */
+    private Integer gridPort;
+}
+

--- a/src/main/java/com/example/aqa/driver/PlaywrightBasedAppDriver.java
+++ b/src/main/java/com/example/aqa/driver/PlaywrightBasedAppDriver.java
@@ -1,0 +1,49 @@
+package com.example.aqa.driver;
+
+import com.microsoft.playwright.Page;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * {@link AppDriver} implementation backed by Playwright's {@link Page}.
+ * <p>
+ * The implementation mirrors the Selenium and Appium counterparts while
+ * delegating operations to Playwright. Tests remain technology agnostic by
+ * interacting only with the {@link AppDriver} interface.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class PlaywrightBasedAppDriver implements AppDriver {
+
+    /** Underlying Playwright page executing commands in a browser. */
+    private final Page page;
+
+    /** {@inheritDoc} */
+    @Override
+    public void click(String locator) {
+        log.info("Clicking on element with locator: {} by playwright driver", locator);
+        page.locator(locator).click();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getText(String locator) {
+        log.info("Getting text from element with locator: {} by playwright driver", locator);
+        return page.locator(locator).innerText();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void sendText(String locator, String text) {
+        log.info("Sending text '{}' to element with locator: {} by playwright driver", text, locator);
+        page.locator(locator).fill(text);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void waitObject(String locator) {
+        log.info("Waiting for element with locator: {} by playwright driver", locator);
+        page.locator(locator).waitFor();
+    }
+}
+

--- a/src/main/resources/playwright.properties
+++ b/src/main/resources/playwright.properties
@@ -1,0 +1,4 @@
+playwright.app-host=localhost
+playwright.app-port=1234
+playwright.grid-host=http://127.0.0.1
+playwright.grid-port=9222


### PR DESCRIPTION
## Summary
- add Playwright-based AppDriver implementation
- wire Playwright page via Spring profile-based configuration and properties
- document Playwright usage and configuration

## Testing
- `mvn -q -Dspring.profiles.active=mock test` *(fails: Non-resolvable parent POM for com.example:template:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_689b581751d88326ad979830a146a7f6