### PR TITLE
Add JavaDoc for newly added driver method and page objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ src/test/java
 
 Configuration files for the examples live under `src/main/resources`.
 
+## Sample Page Objects and Test
+
+The project includes a small demonstration feature composed of the
+`ElementsPage` and `UserCard` page objects along with `ExampleTest`. These
+classes showcase how to build reusable page components and how to verify
+visibility using the new `isDisplayed` method on `AppDriver` implementations.
+
 ## Configuration Properties
 
 Several `.properties` files under `src/main/resources` control the behaviour of

--- a/src/main/java/com/example/aqa/app/client/example/ElementsPage.java
+++ b/src/main/java/com/example/aqa/app/client/example/ElementsPage.java
@@ -5,16 +5,38 @@ import com.example.aqa.driver.AppDriver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+/**
+ * Page object representing the elements screen in the sample application.
+ * <p>
+ * Methods return lightweight {@link AppObject} instances for individual
+ * controls, allowing tests to compose interactions fluently.
+ */
 @Component
 @RequiredArgsConstructor
 public class ElementsPage {
 
+    /** Driver used to create page element objects. */
     private final AppDriver appDriver;
 
+    /**
+     * Returns the search button element.
+     *
+     * @return {@link AppObject} representing the search button
+     */
     public AppObject searchButton() { return new AppObject(appDriver, "//button[@id='search']"); }
 
+    /**
+     * Returns the search input field element.
+     *
+     * @return {@link AppObject} representing the search input field
+     */
     public AppObject searchInput() { return new AppObject(appDriver, "//input[@name='username']"); }
 
+    /**
+     * Returns the user card section containing user information.
+     *
+     * @return {@link UserCard} representing the user card
+     */
     public UserCard userCard() { return new UserCard(appDriver, "(//div[@class='card-content'])[1]"); }
 
 }

--- a/src/main/java/com/example/aqa/app/client/example/UserCard.java
+++ b/src/main/java/com/example/aqa/app/client/example/UserCard.java
@@ -3,14 +3,33 @@ package com.example.aqa.app.client.example;
 import com.example.aqa.app.client.object.AppObject;
 import com.example.aqa.driver.AppDriver;
 
+/**
+ * Page object representing a user's summary card displayed after performing a search.
+ */
 public class UserCard extends AppObject {
 
+    /**
+     * Creates a new user card page object.
+     *
+     * @param appDriver driver used for element interactions
+     * @param locator locator identifying the user card root element
+     */
     public UserCard(AppDriver appDriver, String locator) {
         super(appDriver, locator);
     }
 
+    /**
+     * Returns the avatar image element within the user card.
+     *
+     * @return {@link AppObject} for the user avatar
+     */
     public AppObject avatar() { return new AppObject(appDriver, "//figure[@class='image is-128x128']"); }
 
+    /**
+     * Returns the element displaying the number of public repositories.
+     *
+     * @return {@link AppObject} for the public repositories number
+     */
     public AppObject publicReposNumber() { return new AppObject(appDriver, "(//p[@class='title is-5'])[1]"); }
 
 }

--- a/src/main/java/com/example/aqa/app/client/object/AppObject.java
+++ b/src/main/java/com/example/aqa/app/client/object/AppObject.java
@@ -45,6 +45,11 @@ public class AppObject {
         appDriver.sendText(locator, text);
     }
 
+    /**
+     * Indicates whether the element represented by this object is displayed.
+     *
+     * @return {@code true} if the element is displayed, {@code false} otherwise
+     */
     public boolean isDisplayed() {
         return appDriver.isDisplayed(locator);
     }

--- a/src/main/java/com/example/aqa/driver/AppDriver.java
+++ b/src/main/java/com/example/aqa/driver/AppDriver.java
@@ -33,6 +33,12 @@ public interface AppDriver {
      */
     void sendText(String locator, String text);
 
+    /**
+     * Checks whether an element identified by the provided locator is displayed.
+     *
+     * @param locator element locator
+     * @return {@code true} if the element is displayed, {@code false} otherwise
+     */
     boolean isDisplayed(String locator);
 
     /**

--- a/src/main/java/com/example/aqa/driver/AppiumBasedAppDriver.java
+++ b/src/main/java/com/example/aqa/driver/AppiumBasedAppDriver.java
@@ -45,6 +45,7 @@ public class AppiumBasedAppDriver implements AppDriver {
         appiumDriver.findElement(By.xpath(locator)).sendKeys(text);
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isDisplayed(String locator) {
         return appiumDriver.findElement(By.xpath(locator)).isDisplayed();

--- a/src/main/java/com/example/aqa/driver/MockAppDriver.java
+++ b/src/main/java/com/example/aqa/driver/MockAppDriver.java
@@ -33,6 +33,7 @@ public class MockAppDriver implements AppDriver {
         log.info("Mock sendText on locator: {}, text: {}", locator, text);
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isDisplayed(String locator) {
         return true;

--- a/src/main/java/com/example/aqa/driver/PlaywrightBasedAppDriver.java
+++ b/src/main/java/com/example/aqa/driver/PlaywrightBasedAppDriver.java
@@ -39,6 +39,7 @@ public class PlaywrightBasedAppDriver implements AppDriver {
         page.locator(locator).fill(text);
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isDisplayed(String locator) {
         return page.locator(locator).isVisible();

--- a/src/main/java/com/example/aqa/driver/SeleniumBasedAppDriver.java
+++ b/src/main/java/com/example/aqa/driver/SeleniumBasedAppDriver.java
@@ -45,6 +45,7 @@ public class SeleniumBasedAppDriver implements AppDriver {
         webDriver.findElement(By.xpath(locator)).sendKeys(text);
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isDisplayed(String locator) {
         return webDriver.findElement(By.xpath(locator)).isDisplayed();

--- a/src/test/java/com/example/aqa/ExampleTest.java
+++ b/src/test/java/com/example/aqa/ExampleTest.java
@@ -8,13 +8,20 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 
+/**
+ * Demonstrates interaction with {@link ElementsPage} and nested page objects.
+ */
 @Slf4j
 class ExampleTest extends BaseTest {
 
+    /** Page object providing access to screen elements. */
     @Autowired
     private ElementsPage elementsPage;
 
 
+    /**
+     * End-to-end example verifying visibility and interactions on the elements page.
+     */
     @Test
     @DisplayName("Example test")
     void exampleTest() {


### PR DESCRIPTION
## Summary
- Document the new `isDisplayed` method in `AppDriver` and its implementations
- Flesh out JavaDoc for `AppObject`, `ElementsPage`, `UserCard`, and `ExampleTest`
- Mention sample page objects and test in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.example:template:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_689c846841c48326b648ee608c334895