### PR TITLE
feat: add feign-based REST client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <appium.java-client.version>9.5.0</appium.java-client.version>
         <lombok.version>1.18.38</lombok.version>
         <rest-assured.version>5.5.5</rest-assured.version>
+        <spring-cloud-openfeign.version>4.1.2</spring-cloud-openfeign.version>
         <assertj-core.version>3.27.3</assertj-core.version>
         <awaitility.version>4.3.0</awaitility.version>
         <jackson-databind.version>2.19.2</jackson-databind.version>
@@ -84,11 +85,17 @@
             <version>${lombok.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>io.rest-assured</groupId>
-            <artifactId>rest-assured</artifactId>
-            <version>${rest-assured.version}</version>
-        </dependency>
+          <dependency>
+              <groupId>io.rest-assured</groupId>
+              <artifactId>rest-assured</artifactId>
+              <version>${rest-assured.version}</version>
+          </dependency>
+
+          <dependency>
+              <groupId>org.springframework.cloud</groupId>
+              <artifactId>spring-cloud-starter-openfeign</artifactId>
+              <version>${spring-cloud-openfeign.version}</version>
+          </dependency>
 
         <dependency>
             <groupId>org.assertj</groupId>

--- a/src/main/java/com/example/aqa/app/server/FeignRestApiClient.java
+++ b/src/main/java/com/example/aqa/app/server/FeignRestApiClient.java
@@ -1,0 +1,30 @@
+package com.example.aqa.app.server;
+
+import com.example.aqa.app.server.model.Something;
+import com.example.aqa.app.server.model.Token;
+import com.example.aqa.app.server.model.User;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * {@link RestApiClient} implementation backed by a Feign client.
+ */
+@RequiredArgsConstructor
+public class FeignRestApiClient implements RestApiClient {
+
+    private final ServerFeignClient serverFeignClient;
+
+    @Override
+    public Token auth(String username, String password) {
+        return serverFeignClient.auth(new User(username, password));
+    }
+
+    @Override
+    public Something getSomething() {
+        return serverFeignClient.getSomething();
+    }
+
+    @Override
+    public Something createSomething(String stringValue, int intValue) {
+        return serverFeignClient.createSomething(new Something(stringValue, intValue));
+    }
+}

--- a/src/main/java/com/example/aqa/app/server/RestApiClient.java
+++ b/src/main/java/com/example/aqa/app/server/RestApiClient.java
@@ -2,85 +2,35 @@ package com.example.aqa.app.server;
 
 import com.example.aqa.app.server.model.Something;
 import com.example.aqa.app.server.model.Token;
-import com.example.aqa.app.server.model.User;
-import io.restassured.RestAssured;
-import io.restassured.filter.log.RequestLoggingFilter;
-import io.restassured.filter.log.ResponseLoggingFilter;
 
 /**
- * Simple REST client used for demonstrating API interactions with {@link RestAssured}.
- * <p>
- * The client intentionally configures base URI and logging globally so that
- * individual tests remain concise. It showcases how service clients can be
- * registered as Spring beans and reused across tests.
+ * Common REST API client contract used by tests.
+ * Implementations can use different HTTP stacks such as RestAssured or Feign.
  */
-public class RestApiClient {
+public interface RestApiClient {
 
     /**
-     * Creates a client and configures RestAssured base URI and logging filters.
-     * <p>
-     * Centralising this setup keeps tests free from repetitive configuration and
-     * ensures every request/response is logged for easier debugging.
+     * Performs authentication and returns an access token.
      *
-     * @param host API host
-     * @param port API port
+     * @param username user name
+     * @param password user password
+     * @return authentication token
      */
-    public RestApiClient(String host, Integer port) {
-
-        if (port != null) {
-            RestAssured.baseURI = String.format("%s:%d", host, port);
-        } else {
-            RestAssured.baseURI = String.format(host);
-        }
-        RestAssured.filters(new RequestLoggingFilter(), new ResponseLoggingFilter());
-    }
-
-
-    public Token auth(String username, String password) {
-        return RestAssured.given()
-                .body(new User(username, password))
-                .when()
-                .contentType("application/json")
-                .post("/auth")
-                .then()
-                .extract()
-                .response()
-                .as(Token.class);
-    }
+    Token auth(String username, String password);
 
     /**
-     * Retrieves a {@link Something} entity from the server.
+     * Retrieves a {@link Something} from the server.
      *
-     * @return object returned by the <code>/something</code> endpoint
+     * @return entity returned by the service
      */
-    public Something getSomething() {
-        return RestAssured.given()
-                .when()
-                .get("/something")
-                .then()
-                .extract()
-                .response()
-                .as(Something.class);
-    }
+    Something getSomething();
 
     /**
-     * Sends a request to create a {@link Something} entity on the server.
+     * Creates a {@link Something} entity on the server.
      *
-     * @param stringValue string value to set
-     * @param intValue    integer value to set
-     * @return created object returned by the server
+     * @param stringValue string value
+     * @param intValue numeric value
+     * @return created entity
      */
-    public Something createSomething(String stringValue, int intValue) {
-        return RestAssured.given()
-                .body(new Something(stringValue, intValue))
-                .when()
-                .put("/something")
-                .then()
-                .extract()
-                .response()
-                .as(Something.class);
-    }
+    Something createSomething(String stringValue, int intValue);
 }
-
-
-

--- a/src/main/java/com/example/aqa/app/server/RestAssuredRestApiClient.java
+++ b/src/main/java/com/example/aqa/app/server/RestAssuredRestApiClient.java
@@ -1,0 +1,89 @@
+package com.example.aqa.app.server;
+
+import com.example.aqa.app.server.model.Something;
+import com.example.aqa.app.server.model.Token;
+import com.example.aqa.app.server.model.User;
+import io.restassured.RestAssured;
+import io.restassured.filter.log.RequestLoggingFilter;
+import io.restassured.filter.log.ResponseLoggingFilter;
+
+/**
+ * {@link RestApiClient} implementation using RestAssured for HTTP calls.
+ * <p>
+ * The class is kept mainly for demonstration purposes; the framework now
+ * prefers a Feign based client but still offers this implementation as an
+ * example of a RestAssured-based approach.
+ */
+public class RestAssuredRestApiClient implements RestApiClient {
+
+    /**
+     * Creates a client and configures RestAssured base URI and logging filters.
+     * <p>
+     * Centralising this setup keeps tests free from repetitive configuration and
+     * ensures every request/response is logged for easier debugging.
+     *
+     * @param host API host
+     * @param port API port
+     */
+    public RestAssuredRestApiClient(String host, Integer port) {
+
+        if (port != null) {
+            RestAssured.baseURI = String.format("%s:%d", host, port);
+        } else {
+            RestAssured.baseURI = String.format(host);
+        }
+        RestAssured.filters(new RequestLoggingFilter(), new ResponseLoggingFilter());
+    }
+
+
+    @Override
+    public Token auth(String username, String password) {
+        return RestAssured.given()
+                .body(new User(username, password))
+                .when()
+                .contentType("application/json")
+                .post("/auth")
+                .then()
+                .extract()
+                .response()
+                .as(Token.class);
+    }
+
+    /**
+     * Retrieves a {@link Something} entity from the server.
+     *
+     * @return object returned by the <code>/something</code> endpoint
+     */
+    @Override
+    public Something getSomething() {
+        return RestAssured.given()
+                .when()
+                .get("/something")
+                .then()
+                .extract()
+                .response()
+                .as(Something.class);
+    }
+
+    /**
+     * Sends a request to create a {@link Something} entity on the server.
+     *
+     * @param stringValue string value to set
+     * @param intValue    integer value to set
+     * @return created object returned by the server
+     */
+    @Override
+    public Something createSomething(String stringValue, int intValue) {
+        return RestAssured.given()
+                .body(new Something(stringValue, intValue))
+                .when()
+                .put("/something")
+                .then()
+                .extract()
+                .response()
+                .as(Something.class);
+    }
+}
+
+
+

--- a/src/main/java/com/example/aqa/app/server/ServerFeignClient.java
+++ b/src/main/java/com/example/aqa/app/server/ServerFeignClient.java
@@ -1,0 +1,27 @@
+package com.example.aqa.app.server;
+
+import com.example.aqa.app.server.model.Something;
+import com.example.aqa.app.server.model.Token;
+import com.example.aqa.app.server.model.User;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.http.MediaType;
+
+/**
+ * Feign declaration of the server API.
+ */
+@FeignClient(name = "serverClient", url = "${server.host}")
+public interface ServerFeignClient {
+
+    @PostMapping(path = "/auth", consumes = MediaType.APPLICATION_JSON_VALUE)
+    Token auth(@RequestBody User user);
+
+    @GetMapping("/something")
+    Something getSomething();
+
+    @PutMapping(path = "/something", consumes = MediaType.APPLICATION_JSON_VALUE)
+    Something createSomething(@RequestBody Something something);
+}

--- a/src/main/java/com/example/aqa/configuration/rest/RestApiClientConfiguration.java
+++ b/src/main/java/com/example/aqa/configuration/rest/RestApiClientConfiguration.java
@@ -1,6 +1,9 @@
 package com.example.aqa.configuration.rest;
 
+import com.example.aqa.app.server.FeignRestApiClient;
 import com.example.aqa.app.server.RestApiClient;
+import com.example.aqa.app.server.ServerFeignClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,24 +15,20 @@ import org.springframework.context.annotation.Configuration;
  * across tests and can easily swap the implementation if needed.
  */
 @Configuration
+@EnableFeignClients(clients = ServerFeignClient.class)
 @EnableConfigurationProperties(ServerProperties.class)
 public class RestApiClientConfiguration {
 
     /**
-     * Creates a {@link RestApiClient} bean configured with server properties.
-     * <p>
-     * The server details are externalized in {@link ServerProperties} so the
-     * same test code can target different environments simply by changing
-     * configuration files.
+     * Provides a {@link RestApiClient} backed by a Feign HTTP client.
      *
-     * @param serverProperties server connection settings
-     * @return configured REST client
+     * @param serverFeignClient Feign declaration of the server endpoints
+     * @return implementation used in tests
      */
     @Bean
-    public RestApiClient restApiClient(ServerProperties serverProperties) {
-        return new RestApiClient(serverProperties.getHost(), serverProperties.getPort());
+    public RestApiClient restApiClient(ServerFeignClient serverFeignClient) {
+        return new FeignRestApiClient(serverFeignClient);
     }
-
 }
 
 


### PR DESCRIPTION
## Summary
- introduce Feign-based REST API client and keep RestAssured implementation for reference
- wire Feign client in configuration and drop RestAssured bean
- add Spring Cloud OpenFeign dependency

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.example:template)*

------
https://chatgpt.com/codex/tasks/task_e_689cabb918948326bb5b634244451a2d