### PR TITLE
docs: refresh javadocs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This project demonstrates a minimal yet extensible setup for building automated
 tests in Java. It combines Spring Boot for dependency management, JUnit 5 for
-testing, and optional Appium and Selenium integrations for mobile and web
-automation. The framework contains examples of page objects, REST clients,
-custom JUnit extensions and configuration classes.
+testing, and optional Appium, Selenium and Playwright integrations for mobile
+and web automation. The framework contains examples of page objects, REST
+clients, custom JUnit extensions and configuration classes.
 
 ## Prerequisites
 
@@ -31,7 +31,8 @@ Configuration files for the examples live under `src/main/resources`.
 The project includes a small demonstration feature composed of the
 `ElementsPage` and `UserCard` page objects along with `ExampleTest`. These
 classes showcase how to build reusable page components and how to verify
-visibility using the new `isDisplayed` method on `AppDriver` implementations.
+visibility using the `isDisplayed` method and wait for elements with the
+`waitObject` helper on `AppDriver` implementations.
 
 ## Configuration Properties
 

--- a/src/main/java/com/example/aqa/app/server/FeignRestApiClient.java
+++ b/src/main/java/com/example/aqa/app/server/FeignRestApiClient.java
@@ -7,22 +7,29 @@ import lombok.RequiredArgsConstructor;
 
 /**
  * {@link RestApiClient} implementation backed by a Feign client.
+ * <p>
+ * Delegates all operations to the generated {@link ServerFeignClient} while
+ * keeping the rest of the framework technology agnostic.
  */
 @RequiredArgsConstructor
 public class FeignRestApiClient implements RestApiClient {
 
+    /** Feign client proxy for the server API. */
     private final ServerFeignClient serverFeignClient;
 
+    /** {@inheritDoc} */
     @Override
     public Token auth(String username, String password) {
         return serverFeignClient.auth(new User(username, password));
     }
 
+    /** {@inheritDoc} */
     @Override
     public Something getSomething() {
         return serverFeignClient.getSomething();
     }
 
+    /** {@inheritDoc} */
     @Override
     public Something createSomething(String stringValue, int intValue) {
         return serverFeignClient.createSomething(new Something(stringValue, intValue));

--- a/src/main/java/com/example/aqa/app/server/ServerFeignClient.java
+++ b/src/main/java/com/example/aqa/app/server/ServerFeignClient.java
@@ -16,12 +16,29 @@ import org.springframework.http.MediaType;
 @FeignClient(name = "serverClient", url = "${server.host}")
 public interface ServerFeignClient {
 
+    /**
+     * Authenticates the given user.
+     *
+     * @param user credentials to authenticate
+     * @return access token issued by the service
+     */
     @PostMapping(path = "/auth", consumes = MediaType.APPLICATION_JSON_VALUE)
     Token auth(@RequestBody User user);
 
+    /**
+     * Retrieves an example entity from the server.
+     *
+     * @return {@link Something} returned by the API
+     */
     @GetMapping("/something")
     Something getSomething();
 
+    /**
+     * Creates or replaces the example entity on the server.
+     *
+     * @param something entity to send to the API
+     * @return stored entity representation
+     */
     @PutMapping(path = "/something", consumes = MediaType.APPLICATION_JSON_VALUE)
     Something createSomething(@RequestBody Something something);
 }

--- a/src/main/java/com/example/aqa/app/server/model/Token.java
+++ b/src/main/java/com/example/aqa/app/server/model/Token.java
@@ -7,7 +7,11 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+/**
+ * Authentication token returned by the sample REST service.
+ */
 public class Token {
 
+    /** Encoded access token string. */
     private String token;
 }

--- a/src/main/java/com/example/aqa/app/server/model/User.java
+++ b/src/main/java/com/example/aqa/app/server/model/User.java
@@ -7,8 +7,14 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+/**
+ * Credentials used for authentication requests.
+ */
 public class User {
 
+    /** Login user name. */
     private String username;
+
+    /** Plain text password. */
     private String password;
 }

--- a/src/main/java/com/example/aqa/configuration/rest/RestApiClientConfiguration.java
+++ b/src/main/java/com/example/aqa/configuration/rest/RestApiClientConfiguration.java
@@ -24,6 +24,11 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 @Import(FeignAutoConfiguration.class)
 public class RestApiClientConfiguration {
 
+    /**
+     * Registers JSON message converters used by Feign clients.
+     *
+     * @return container with a Jackson converter
+     */
     @Bean
     public HttpMessageConverters messageConverters() {
         return new HttpMessageConverters(new MappingJackson2HttpMessageConverter());


### PR DESCRIPTION
## Summary
- document REST model classes and Feign clients
- clarify REST API client configuration beans
- mention Playwright support and element waiting in README

## Testing
- `mvn -q test` *(fails: Could not resolve parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689dac6e6794832688f19a7eccbec37d